### PR TITLE
Update commands in bumpAframeDist script

### DIFF
--- a/lib/bumpAframeDist.js
+++ b/lib/bumpAframeDist.js
@@ -24,7 +24,7 @@ function bumpAframeDist (data) {
     async.series([
       execCommand('git reset --hard HEAD', 'aframe'),
       execCommand('git pull --rebase origin master', 'aframe'),
-      execCommand('npm install --only="dev"', 'aframe'),
+      execCommand('rm package-lock.json', 'aframe'),
       execCommand('npm install', 'aframe'),
       execCommand('npm run dist', 'aframe'),
       execCommand('git status', 'aframe'),


### PR DESCRIPTION
`npm install` already installs devDependencies, remove package-lock.json to get latest dependencies

`npm install --only="dev"` gives warnings
```
npm warn invalid config only="dev" set in command line options
npm warn invalid config Must be one of: null, prod, production
```
so it was just doing `npm install` twice here.